### PR TITLE
Update presentation and ensure settings are persisted

### DIFF
--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -211,9 +211,7 @@ QUITTT:
 
 				rts
 
-customOptionsBuffer:
-quakeMouse:			dc.b	0
-alwaysRun			dc.b	0
+
 
 ; PREFERENCES (TODO - SHIP OUT):
 
@@ -285,6 +283,11 @@ Prefs_Unused_b:	dc.b	0
 
 	DECLC	Prefs_GammaLevel_RTG_b
 		dc.b	0
+
+    ; Moved here to be included in the persisted preferences
+Prefs_CustomOptionsBuffer_vb:
+Prefs_OriginalMouse_b:		dc.b	0
+Prefs_AlwaysRun_b:			dc.b	0
 
                 align 4
 _Prefs_PersistedEnd::
@@ -561,24 +564,36 @@ DEFGAME:
 				not.b	LOADEXT;			 reset for next load
 				rts
 ***************************************************************
+
+
+
 customOptions:
 ;fixme: there are better ways to do this, but it works (of sorts).AL
-.redraw
+.redraw:
 ; copy current setting over to menu
-				move.l	#customOptionsBuffer,a0
+				move.l	#Prefs_CustomOptionsBuffer_vb,a0
 				move.l	#optionLines+17,a1
 				moveq	#1,d1
-.copyOpts
+.copyOpts:
 				move.b	(a0)+,d0
-				add.b	#132,d0		;start of the keyboard layout
-				add.b	#24,d0		;cos i and o look like 1 and 0 in the menu font
+
+				bne.s   .enabled
+				move.b  #'N',d0
+				bra.s   .copy
+.enabled:
+                move.b  #'Y',d0
+
+				;add.b	#132,d0		;start of the keyboard layout
+				;add.b	#24,d0		;cos i and o look like 1 and 0 in the menu font
+
+.copy:
 				move.b	d0,(a1)
 				add.l	#21,a1		;end of the line/start of next i guess
 				dbra	d1,.copyOpts
 
 				lea		mnu_MYCUSTOMOPTSMENU,a0
 				bsr		MYOPENMENU
-.rdloop
+.rdloop:
 				lea		mnu_MYCUSTOMOPTSMENU,a0
 				bsr		CHECKMENU
 
@@ -587,45 +602,46 @@ customOptions:
 
 				cmp.w	#0,d0
 				bne.s	.co2
-				not.b	quakeMouse
+				not.b	Prefs_OriginalMouse_b
 				bra	.w8
-.co2
+.co2:
 				cmp.w	#1,d0
 				bne.s	.co3
-				not.b	alwaysRun
+				not.b	Prefs_AlwaysRun_b
 				bra	.w8
-.co3
+.co3:
 				cmp.w	#2,d0
 				bne.s	.co4
 				bra	.w8
-.co4
+.co4:
 				cmp.w	#3,d0
 				bne.s	.co5
 				bra	.w8
-.co5
+.co5:
 				cmp.w	#4,d0
 				bne.s	.co6
 				;opt5
 				bra	.w8
-.co6
+.co6:
 				cmp.w	#5,d0
 				bne.s	.co7
 				;opt6
 				bra	.w8
-.co7
+.co7:
 				cmp.w	#6,d0
 				bne.s	.co8
 				;opt7
 				bra	.w8
-.co8
+.co8:
 				cmp.w	#7,d0
 				bne.s	.w8
 				;opt8
-.w8
+.w8:
 				lea		mnu_MYCUSTOMOPTSMENU,a0
 				jsr		mnu_redraw
 				bra		.redraw
-.customOptionsDone
+
+.customOptionsDone:
 				rts
 ***************************************************************
 playgame:

--- a/ab3d2_source/menu/menunb.s
+++ b/ab3d2_source/menu/menunb.s
@@ -1599,14 +1599,14 @@ mnu_MYCUSTOMOPTSTEXT:
 				dc.b	'                    ',1
 				dc.b	'                    ',1
 optionLines:				;12345678901234567890
-				dc.b	'  -QUAKE MOUSE      ',1;OFF  ',1
-				dc.b	'  --ALWAYS RUN      ',1;OFF  ',1
-				dc.b	'  OPTION     3  N/A ',1;OFF  ',1
-				dc.b	'  OPTION     4  N/A ',1;OFF  ',1
-				dc.b	'  OPTION     5  N/A ',1
-				dc.b	'  OPTION     6  N/A ',1
-				dc.b	'  OPTION     7  N/A ',1
-				dc.b	'  OPTION     8  N/A ',1
+				dc.b	'  ORIGINAL MOUSE    ',1;OFF  ',1
+				dc.b	'  ALWAYS RUN        ',1;OFF  ',1
+				dc.b	'  OPTION 3          ',1;OFF  ',1
+				dc.b	'  OPTION 4          ',1;OFF  ',1
+				dc.b	'  OPTION 5          ',1
+				dc.b	'  OPTION 6          ',1
+				dc.b	'  OPTION 7          ',1
+				dc.b	'  OPTION 8          ',1
 				dc.b	'     MAIN  MENU     ',0
 				EVEN
 ***************************************************************

--- a/ab3d2_source/modules/player.s
+++ b/ab3d2_source/modules/player.s
@@ -146,7 +146,7 @@ plr_MouseControl:
 
 				; The right mouse button triggers the next_weapon key
 				move.b	next_weapon_key,d7
-				tst.b	quakeMouse
+				tst.b	Prefs_OriginalMouse_b
 				beq.s	.notQuake
 				move.b	forward_key,d7
 .notQuake
@@ -510,8 +510,8 @@ plr_KeyboardControl:
 				move.w	PlrT_SnapAngPos_w(a0),d0
 				move.w	PlrT_SnapAngSpd_w(a0),d3
 ***************************************************************
-				tst.b	alwaysRun
-				bne.s	.alwaysRun
+				tst.b	Prefs_AlwaysRun_b
+				bne.s	.always_run
 				move.w	#35,d1
 				move.w	#2,d2
 				move.w	#10,Plr_TurnSpeed_w
@@ -524,8 +524,8 @@ plr_KeyboardControl:
 				move.w	#14,Plr_TurnSpeed_w
 .nofaster:
 				bra	.faster
-.alwaysRun:
 
+.always_run:
 				move.w	#60,d1
 				move.w	#3,d2
 				move.w	#14,Plr_TurnSpeed_w


### PR DESCRIPTION
- Updates presentation:
    - Quake Mouse is now Original Mouse
    - 1 and 0 are replaced with Y and N
    - Slightly less text in unused options
 
- Renames control variables to match source style and moves into the PrefsFile section to ensure they are stored between sessions.