### PR TITLE
Crosshair modifications

### DIFF
--- a/ab3d2_source/controlloop.s
+++ b/ab3d2_source/controlloop.s
@@ -245,6 +245,8 @@ centre_view_key:	dc.b	RAWKEY_SEMICOLON
 next_weapon_key:	dc.b	RAWKEY_BSLASH
 spare_key:          dc.b    0
 
+    ; DECLC Macro makes the identifier visible to C also
+
 	DECLC	Prefs_FullScreen_b
 		dc.b	0
 
@@ -289,11 +291,20 @@ Prefs_Unused_b:	dc.b	0
 
     ; Moved here to be included in the persisted preferences
 Prefs_CustomOptionsBuffer_vb:
-Prefs_OriginalMouse_b:		dc.b	0
-Prefs_AlwaysRun_b:			dc.b	0
+    DECLC   Prefs_OriginalMouse_b
+        dc.b	0
+
+    DECLC   Prefs_AlwaysRun_b
+        dc.b	0
+
     DECLC   Prefs_ShowMessages_b
         dc.b    255
-Prefs_AutoAim_b:			dc.b	0
+
+    DECLC   Prefs_AutoAim_b
+        dc.b	0
+
+    DECLC   Prefs_CrossHairColour_b
+        dc.b    0
 
                 align 4
 _Prefs_PersistedEnd::

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -380,25 +380,52 @@ Draw_Crosshair:
 				tst.b	Vid_FullScreen_b
 				beq.s	.small
 
-				cmp.w	#0,STOPOFFSET
-				ble.s .above
-
 				move.w	 STOPOFFSET,d1
-				divs.w #9,d1
-				muls.w #SCREEN_WIDTH,d1
+                ble.s   .above
+
+				muls.w  #(256/9),d1
+				asr.l   #8,d1
+
+				and.b   #$fe,d1
+
+				muls.w  #SCREEN_WIDTH,d1
+
 				add.w d1,d0
 				bra.s	.below
 
 .above
-				move.w	 STOPOFFSET,d1
+;				move.w	 STOPOFFSET,d1
 				neg.w	d1
-				divs.w #9,d1
-				muls.w #SCREEN_WIDTH,d1
+				;divs.w #9,d1
+				;muls.w #SCREEN_WIDTH,d1
+
+				muls.w  #(256/9),d1
+				asr.l   #8,d1
+
+                and.b   #$fe,d1
+
+
+				muls.w  #SCREEN_WIDTH,d1
+
 				sub.w d1,d0
 
 .below
 ***************************************************************
 .small
+
 				add.l	d0,a0
-				move.b	#255,(a0)
+
+				move.b  #254,d0
+				move.b	d0,-4*SCREEN_WIDTH-4(a0) ; TL
+				move.b	d0,-4*SCREEN_WIDTH+4(a0) ; TR
+                move.b	d0,-2*SCREEN_WIDTH-2(a0) ; TL
+				move.b	d0,-2*SCREEN_WIDTH+2(a0) ; TR
+
+				move.b	d0,2*SCREEN_WIDTH-2(a0) ; BL
+				move.b	d0,2*SCREEN_WIDTH+2(a0) ; BR
+				move.b	d0,4*SCREEN_WIDTH-4(a0) ; BL
+				move.b	d0,4*SCREEN_WIDTH+4(a0) ; BR
+
+
+
 				rts

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -370,6 +370,16 @@ Draw_NarrateText:
 				rts
 
 Draw_Crosshair:
+                ; Get the pen
+                clr.l   d0
+				move.b  Prefs_CrossHairColour_b,d0
+				and.b   #7,d0 ; paranoia
+				move.l  #Draw_CrosshairPens_vb,a1
+				add.w   d0,a1
+				tst.b   (a1)
+                beq     .done
+
+
 				move.l	Vid_FastBufferPtr_l,a0
 				add.w	Vid_CentreX_w,a0
 				move.w	Vid_BottomY_w,d0
@@ -404,13 +414,8 @@ Draw_Crosshair:
 .below:
 ***************************************************************
 .small:
-
 				add.l	d0,a0
-                clr.l   d0
-				move.b  Prefs_CrossHairColour_b,d0
-				and.b   #7,d0 ; paranoia
-				move.l  #Draw_CrosshairPens_vb,a1
-				add.w   d0,a1
+
 				move.b  (a1),d0
 
 				; TODO - Mod Properties should define a mechanism to allow per gun
@@ -425,7 +430,7 @@ Draw_Crosshair:
 				move.b	d0,2*SCREEN_WIDTH+2(a0) ; BR
 				move.b	d0,4*SCREEN_WIDTH-4(a0) ; BL
 				move.b	d0,4*SCREEN_WIDTH+4(a0) ; BR
-
+.done:
 				rts
 
 				; TODO - this should be dedefinable by mod and/or user as they are currently defined
@@ -438,4 +443,4 @@ Draw_CrosshairPens_vb:
                 dc.b 250 ; intense red
                 dc.b 133 ; ice blue
                 dc.b  69 ; intense blue
-                dc.b   0 ; black - for use in bright environments
+                dc.b   0 ; off

--- a/ab3d2_source/modules/draw.s
+++ b/ab3d2_source/modules/draw.s
@@ -385,37 +385,37 @@ Draw_Crosshair:
 
 				muls.w  #(256/9),d1
 				asr.l   #8,d1
-
 				and.b   #$fe,d1
-
 				muls.w  #SCREEN_WIDTH,d1
 
 				add.w d1,d0
 				bra.s	.below
 
-.above
-;				move.w	 STOPOFFSET,d1
+.above:
 				neg.w	d1
-				;divs.w #9,d1
-				;muls.w #SCREEN_WIDTH,d1
 
 				muls.w  #(256/9),d1
 				asr.l   #8,d1
-
                 and.b   #$fe,d1
-
-
 				muls.w  #SCREEN_WIDTH,d1
 
 				sub.w d1,d0
 
-.below
+.below:
 ***************************************************************
-.small
+.small:
 
 				add.l	d0,a0
+                clr.l   d0
+				move.b  Prefs_CrossHairColour_b,d0
+				and.b   #7,d0 ; paranoia
+				move.l  #Draw_CrosshairPens_vb,a1
+				add.w   d0,a1
+				move.b  (a1),d0
 
-				move.b  #254,d0
+				; TODO - Mod Properties should define a mechanism to allow per gun
+				;        crosshair designs
+
 				move.b	d0,-4*SCREEN_WIDTH-4(a0) ; TL
 				move.b	d0,-4*SCREEN_WIDTH+4(a0) ; TR
                 move.b	d0,-2*SCREEN_WIDTH-2(a0) ; TL
@@ -426,6 +426,16 @@ Draw_Crosshair:
 				move.b	d0,4*SCREEN_WIDTH-4(a0) ; BL
 				move.b	d0,4*SCREEN_WIDTH+4(a0) ; BR
 
-
-
 				rts
+
+				; TODO - this should be dedefinable by mod and/or user as they are currently defined
+				; by the default palette
+Draw_CrosshairPens_vb:
+                dc.b 255 ; intense green
+                dc.b 254 ; mid green
+                dc.b 190 ; intense yellow
+                dc.b  25 ; bright grey
+                dc.b 250 ; intense red
+                dc.b 133 ; ice blue
+                dc.b  69 ; intense blue
+                dc.b   0 ; black - for use in bright environments

--- a/ab3d2_source/modules/player.s
+++ b/ab3d2_source/modules/player.s
@@ -414,7 +414,13 @@ plr_KeyboardControl:
 				clr.l	Vid_FPSLimit_l
 
 .noframelimit:
+                tst.b   RAWKEY_NUM_DOT(a5)
+                beq.b   .done_normal_keys
+                add.b   #1,Prefs_CrossHairColour_b
+                and.b   #7,Prefs_CrossHairColour_b
+                clr.b   RAWKEY_NUM_DOT(a5)
 
+.done_normal_keys:
 				IFD DEV
 
 .toggle_skip_sky_for_zone:


### PR DESCRIPTION
Modifies the crosshair into an X shape that is designed to work and track in both 1x1 and 1x2 pixelmodes. Hopefully it will also work in 2x2 if we ever resurrect it.

Other changes:
- Replaced the division with muls/asr pair
- Chose the darker HUD green for the crosshar as it's less intrusive.
- Crosshair Y position tracks in increments of 2 pixels in fullscreenmode, ensuring that it's always rendered correctly in 1x1 and 1x2 modes
![cross_1x1](https://github.com/user-attachments/assets/c2aa84ca-0658-49d7-a89c-9be64aa50848)
![cross_1x2](https://github.com/user-attachments/assets/1646a3a0-208b-478f-88a2-3f4c958a4208)
